### PR TITLE
changed global mixin to local mixin, add 404 redirection.

### DIFF
--- a/blog_project/frontend/src/components/Blog.vue
+++ b/blog_project/frontend/src/components/Blog.vue
@@ -10,10 +10,12 @@
 <script>
     import axios from 'axios';
     
+    import articleUrlMixin from '/src/mixins/articleUrlMixin';
     import BlogArticle from '/src/components/BlogArticle.vue';
     import BlogArticleList from '/src/components/BlogArticleList.vue';
     
     export default {
+        mixins: [articleUrlMixin],
         data() {
             return {
                 article: undefined,

--- a/blog_project/frontend/src/components/BlogArticle.vue
+++ b/blog_project/frontend/src/components/BlogArticle.vue
@@ -12,8 +12,6 @@
 </template>
 
 <script>
-    import axios from 'axios';
-    
     export default {
         name: 'blog-article',
         props:{

--- a/blog_project/frontend/src/components/BlogArticleList.vue
+++ b/blog_project/frontend/src/components/BlogArticleList.vue
@@ -1,7 +1,7 @@
 <template>
     <div id="blog-article-list">
         <div v-for="article in articleList" :key="article.id">
-            <router-link :to="`/${article.id}`">
+            <router-link :to="`/article/${article.id}`">
                 {{ article.title }}
             </router-link>
         </div>
@@ -9,8 +9,6 @@
 </template>
 
 <script>
-    import axios from 'axios';
-    
     export default {
         name: 'blog-article-list',
         props:{

--- a/blog_project/frontend/src/components/NotFound.vue
+++ b/blog_project/frontend/src/components/NotFound.vue
@@ -1,0 +1,11 @@
+<template>
+    <div>
+        <h3>
+            404 Not Found
+        </h3>
+    </div>
+</template>
+
+<script>
+export default{}
+</script>

--- a/blog_project/frontend/src/main.js
+++ b/blog_project/frontend/src/main.js
@@ -2,6 +2,5 @@ import { createApp } from 'vue'
 
 import App from './App.vue'
 import router from './router'
-import backendUrlMixin from './mixins/backend_url_mixin'
 
-createApp(App).use(router).mixin(backendUrlMixin).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/blog_project/frontend/src/mixins/articleUrlMixin.js
+++ b/blog_project/frontend/src/mixins/articleUrlMixin.js
@@ -1,6 +1,6 @@
 const api_url = 'http://rest-blog.run.goorm.io/api/'
 
-const backendUrlMixin = {
+export default {
     data() {
         return {
             
@@ -16,4 +16,3 @@ const backendUrlMixin = {
     }
 };
 
-export default backendUrlMixin;

--- a/blog_project/frontend/src/router/index.js
+++ b/blog_project/frontend/src/router/index.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router';
-import Blog from '../components/Blog.vue';
+import Blog from '/src/components/Blog.vue';
+import NotFound from '/src/components/NotFound.vue';
 
 const routes = [
     {
@@ -8,11 +9,20 @@ const routes = [
         component: Blog
     },
     {
-        path: '/:articleId',
+        path: '/NotFound',
+        name: 'NotFound',
+        component: NotFound
+    },
+    {
+        path: '/article/:articleId',
         name: 'ArticleDetail',
         props: true,  // 이 옵션으로 선택한 article의 id가 Blog의 props에 저장된다.
         component: Blog,
     },
+    {
+        path: '/:patchMatch(.*)*', 
+        redirect: '/NotFound'
+    }
 ];
 
 const router = createRouter({


### PR DESCRIPTION
이전에 댓글달았던 것처럼 지역 믹스인으로 깔끔하게 바꿨다.
그리고 이상한 url로 접근할 경우 404 redirect가 일어나도록 추가했다.
router/index.js에 `'/NotFound'` 경로를 추가하고, NotFound 컴포넌트가 렌더되도록 설정했다.
명시된 path에 맞는 url가 없다면 patchMatch로 연결되어 `redirect: '/NotFound'`를 통해 리다이렉트되어 404페이지가 보인다.