### PR TITLE
Divided viewset to apiviews for custom update method.

### DIFF
--- a/blog_project/backend/articles/serializers.py
+++ b/blog_project/backend/articles/serializers.py
@@ -1,16 +1,21 @@
+from django.utils import timezone
+
 from rest_framework import serializers
 
 from backend.articles.models import Article
 
 
-class ArticleSerializer(serializers.HyperlinkedModelSerializer):
+class ArticleSerializer(serializers.ModelSerializer):
     class Meta:
         model = Article
         fields = [
-            'url',
             'id',
             'title',
             'create_at',
             'content',
             'last_modified_at',
         ]
+
+    def update(self, instance, validated_data):
+        validated_data['last_modified_at'] = timezone.now()
+        return super().update(instance, validated_data)

--- a/blog_project/backend/articles/urls.py
+++ b/blog_project/backend/articles/urls.py
@@ -1,0 +1,20 @@
+from django.urls import path
+
+from backend.articles.views import ListCreateArticleAPIView
+from backend.articles.views import RetrieveUpdateDestroyArticleAPIView
+
+
+app_name = 'articles'
+
+urlpatterns = [
+    path(
+        '',
+        ListCreateArticleAPIView.as_view(),
+        name="list_create_article"
+    ),
+    path(
+        '<int:pk>/',
+        RetrieveUpdateDestroyArticleAPIView.as_view(),
+        name="retrieve_update_destroy_article"
+    ),
+]

--- a/blog_project/backend/articles/views.py
+++ b/blog_project/backend/articles/views.py
@@ -1,6 +1,8 @@
 from rest_framework import viewsets
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.generics import ListCreateAPIView
+from rest_framework.generics import RetrieveUpdateDestroyAPIView
 
 from backend.articles.models import Article
 from backend.articles.serializers import ArticleSerializer
@@ -21,3 +23,17 @@ class ArticleViewSet(viewsets.ModelViewSet):
     serializer_class = ArticleSerializer
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticatedOrReadOnly]
+
+
+class ListCreateArticleAPIView(ListCreateAPIView):
+    queryset = Article.objects.all()
+    lookup_field = 'pk'
+    serializer_class = ArticleSerializer
+
+
+class RetrieveUpdateDestroyArticleAPIView(RetrieveUpdateDestroyAPIView):
+    serializer_class = ArticleSerializer
+    queryset = Article.objects.all()
+
+    def update(self, request, *args, **kwargs):
+        return super().update(request, *args, **kwargs)

--- a/blog_project/backend/urls.py
+++ b/blog_project/backend/urls.py
@@ -1,13 +1,7 @@
 from django.urls import path, include
-from rest_framework import routers
-
-from backend.articles.views import ArticleViewSet
-
-router = routers.DefaultRouter()
-router.register(r'articles', ArticleViewSet)
 
 
 urlpatterns = [
-    path('', include(router.urls)),
+    path('articles/', include('backend.articles.urls', namespace='articles')),
     path('profiles/', include('backend.profiles.urls', namespace='profiles')),
 ]


### PR DESCRIPTION
Override update method to refresh last_modified_at field.

**ModelSerializer**로 바꿨다. [무슨 이유](https://www.django-rest-framework.org/api-guide/serializers/#how-hyperlinked-views-are-determined)인지는 공부가 필요하다. 

> There needs to be a way of determining which views should be used for hyperlinking to model instances.
> By default hyperlinks are expected to correspond to a view name that matches the style '{model_name}-detail', and looks up the instance by a pk keyword argument.

이유는 model_name-detail의 name attribute를 가진 view를 찾아내려고 하기 때문이다..
그러나 우리는 그냥 url로 요청이 들어오면 지정된 view를 이어줄 것이기 때문에 딱히 필요가 없다.
url필드를 갖고 있다는 것은 좋지만 의미가 있나 싶다. 그래서 일단 ModelSerializer를 쓰기로...

update 함수를 오버라이딩했다.
상위 객체에서 어떻게 진행되나 살펴봤더니...
https://github.com/encode/django-rest-framework/blob/98e56e0327596db352b35fa3b3dc8355dc9bd030/rest_framework/serializers.py#L968-L992
validated_data의 내용대로 instance.save()를 하더라. 
우리가 하려는건 매우 간단하게 필드값만 갱신해주는 것이므로 validated_data의 값만 수정해 호출했다.

이렇게 만든 APIView를 쓰기 위해 ViewSet을 쪼갰다. 어쩔 수 없이 urlPattern을 더 작성했다.
url parameter로 pk값을 받았고, lookup_field는 기본이 pk인데 왜 또 썼는지 모르겠다.
authentication_classes 이런거는 default option에 있는것과 똑같아서 지웠다.