### PR TITLE
Check Authencicated user.

### DIFF
--- a/blog_project/backend/articles/urls.py
+++ b/blog_project/backend/articles/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
         name="list_create_article"
     ),
     path(
-        '<int:pk>/',
+        '<int:id>/',
         RetrieveUpdateDestroyArticleAPIView.as_view(),
         name="retrieve_update_destroy_article"
     ),

--- a/blog_project/backend/articles/views.py
+++ b/blog_project/backend/articles/views.py
@@ -27,11 +27,11 @@ class ArticleViewSet(viewsets.ModelViewSet):
 
 class ListCreateArticleAPIView(ListCreateAPIView):
     queryset = Article.objects.all()
-    lookup_field = 'pk'
     serializer_class = ArticleSerializer
 
 
 class RetrieveUpdateDestroyArticleAPIView(RetrieveUpdateDestroyAPIView):
+    lookup_field = 'id'
     serializer_class = ArticleSerializer
     queryset = Article.objects.all()
 

--- a/blog_project/frontend/src/App.vue
+++ b/blog_project/frontend/src/App.vue
@@ -12,14 +12,14 @@
 </template>
 
 <script>
-import AppNavigation from '/src/components/AppNavigation'
+    import AppNavigation from '/src/components/AppNavigation'
 
-export default{
-    name: 'App',
-    components: {
-        AppNavigation
-    },
-}
+    export default{
+        name: 'App',
+        components: {
+            AppNavigation
+        },
+    }
 </script>
     
 <style>

--- a/blog_project/frontend/src/components/AppNavigation.vue
+++ b/blog_project/frontend/src/components/AppNavigation.vue
@@ -2,12 +2,12 @@
 <div>
     <div id='nav'>
         <router-link :to="{name: 'ListArticle'}">Blog</router-link>
-        <div v-if="hasNotToken">
-            <router-link :to="{name: 'SignUp'}">Sign Up</router-link>
-            <router-link :to="{name: 'SignIn'}">Sign In</router-link>
+        <div v-if="IsTokenVerified">
+            <router-link :to="{name: 'SignOut'}">Sign Out</router-link>
         </div>
         <div v-else>
-            <router-link :to="{name: 'SignOut'}">Sign Out</router-link>
+            <router-link :to="{name: 'SignUp'}">Sign Up</router-link>
+            <router-link :to="{name: 'SignIn'}">Sign In</router-link>
         </div>
     </div>
 </div>
@@ -15,13 +15,10 @@
 </template>
 
 <script>
+    import { mapState } from 'vuex'
+
     export default{
         name: 'AppNavigation',
-        computed: {
-            hasNotToken(){
-                return this.$store.getters['TokenStorage/HasTokenKey'] == false
-            }
-        }
     }
 </script>
 

--- a/blog_project/frontend/src/components/AppPageNotFound.vue
+++ b/blog_project/frontend/src/components/AppPageNotFound.vue
@@ -3,11 +3,31 @@
         <h3>
             404 Not Found
         </h3>
+        <small>
+            Not matched existing url, {{ getUrl }}.
+        </small>
     </div>
 </template>
 
 <script>
 export default{
-    name: 'AppPageNotFound'
+    name: 'AppPageNotFound',
+    props:{
+        pathMatch: Array
+    },
+    computed:{
+        getUrl(){
+            let url = ''
+            try{
+                this.pathMatch.forEach((path) => {
+                    url += path + '/'
+                })
+                return url
+            }
+            catch{
+                return '/'
+            }
+        },
+    }
 }
 </script>

--- a/blog_project/frontend/src/components/Blog/CreateArticle.vue
+++ b/blog_project/frontend/src/components/Blog/CreateArticle.vue
@@ -36,7 +36,6 @@
                     'CreateArticle', this.article
                 ).then( response => {
                     this.$router.push({name: 'ListArticle'});
-                    console.log('d')
                 }).catch( error => {
                     console.log(error.response)
                 })

--- a/blog_project/frontend/src/components/Blog/ListArticle.vue
+++ b/blog_project/frontend/src/components/Blog/ListArticle.vue
@@ -1,12 +1,14 @@
 <template>
 <div>
-    <div id="blog-create-article">
-        <router-link :to="{name: 'CreateArticle'}">
-            Create Article
-        </router-link>
+    <div v-if="IsTokenVerified">
+        <div id="blog-create-article">
+            <router-link :to="{name: 'CreateArticle'}">
+                Create Article
+            </router-link>
+        </div>
+        <hr>
     </div>
-    <hr>
-    <div id="blog-article-list">
+    <div id="blog-article-list" >
         <div v-for="article in articleList" 
              :key="article.id">
             <router-link :to="{
@@ -20,13 +22,14 @@
 </div>
 </template>
 <script>
+    import { mapState } from 'vuex'
     import { mapGetters } from 'vuex'
 
     export default {
         computed:{
             ...mapGetters({
-                articleList: 'GetArticleList',
-            })
+                articleList: 'GetArticleList'
+            }),
         },
         mounted(){
             this.$store.dispatch('ListArticle').catch(error => {

--- a/blog_project/frontend/src/components/Blog/RetrieveArticle.vue
+++ b/blog_project/frontend/src/components/Blog/RetrieveArticle.vue
@@ -12,7 +12,7 @@
         <br/>
         content : {{ article.content }}
         <hr>
-        <div>
+        <div v-if="IsTokenVerified">
             <button v-on:click="DeleteArticle">
                 Delete!    
             </button>

--- a/blog_project/frontend/src/components/Profile/SignIn.vue
+++ b/blog_project/frontend/src/components/Profile/SignIn.vue
@@ -36,6 +36,7 @@
                 this.$store.dispatch(
                     'SignIn', this.profile
                 ).then(response => {
+                    this.$store.commit('TokenStorage/TokenVerified')
                     this.$router.push({name: 'ListArticle'})
                 }).catch(
                     error => {

--- a/blog_project/frontend/src/components/Profile/SignOut.vue
+++ b/blog_project/frontend/src/components/Profile/SignOut.vue
@@ -8,6 +8,7 @@ export default{
     name: 'Sign Out',
     mounted(){
         this.$store.commit('TokenStorage/ClearTokenData')
+        this.$store.commit('TokenStorage/TokenExpired')
         this.$router.push({name: 'ListArticle'})
     }
 }

--- a/blog_project/frontend/src/main.js
+++ b/blog_project/frontend/src/main.js
@@ -4,4 +4,7 @@ import App from './App.vue'
 import vuexStore from './store/store'
 import router from './router'
 
-createApp(App).use(router).use(vuexStore).mount('#app')
+import tokenMixin from '/src/mixins/tokenMixin'
+
+
+createApp(App).mixin(tokenMixin).use(router).use(vuexStore).mount('#app')

--- a/blog_project/frontend/src/mixins/tokenMixin.js
+++ b/blog_project/frontend/src/mixins/tokenMixin.js
@@ -1,0 +1,10 @@
+export default {
+    computed:{
+        IsTokenVerified() {
+            if(this.$store.state.TokenStorage.verified){
+                return true
+            }
+            return false
+        },
+    }
+}

--- a/blog_project/frontend/src/router/index.js
+++ b/blog_project/frontend/src/router/index.js
@@ -10,11 +10,8 @@ const routes = [
     ...ProfileRoute,
     {
         path: '/:pathMatch(.*)*',  // 그 외 모든 경로를 이곳에서 처리하게 된다.
-        redirect: '/NotFound'  // NotFound로 넘겨진다.
-    },
-    {
-        path: '/NotFound',
         name: 'NotFound',
+        props: true,
         component: AppPageNotFound
     },
 ];

--- a/blog_project/frontend/src/store/AxiosApi/ArticleApi.js
+++ b/blog_project/frontend/src/store/AxiosApi/ArticleApi.js
@@ -40,7 +40,7 @@ const ArticleApi = {
                 url: articleUrl.GetArticleListCreateUrl()
             }).then( response => {
                 // 같은 모듈 내에 있는 mutation은 따로 경로 지정없이 그냥 호출할 수 있다. 
-                commit('SetArticleList', response.data) 
+                commit('SetArticleList', response.data)
             })
         },
         CreateArticle({ commit, rootGetters }, article){

--- a/blog_project/frontend/src/store/AxiosApi/ProfileApi.js
+++ b/blog_project/frontend/src/store/AxiosApi/ProfileApi.js
@@ -10,6 +10,9 @@ const profileUrl = {
     GetSignInUrl: () => {
         return profileApiUrl
     },
+    GetVerifyTokenUrl: () => {
+        return profileApiUrl + 'verify/'
+    }
 }
 
 const ProfileApi = {
@@ -32,7 +35,27 @@ const ProfileApi = {
                     response.data
                 )
             })
-        }
+        },
+        Verify({ commit, state, rootGetters }){
+            // TODO
+            // Promise에 대해 알아야겠다. action은 Promise를 이용해 작성..
+            // 
+            let accessTokenKey = rootGetters['TokenStorage/GetAccessTokenKey']
+            if(accessTokenKey.length == 0){
+                commit('TokenStorage/TokenExpired')
+            }
+            axios({
+                method: 'post',
+                url: profileUrl.GetVerifyTokenUrl(),
+                data: rootGetters['TokenStorage/GetDataForVerification'],
+            }).then( response => {
+                if(response.status == 200){
+                    commit('TokenStorage/TokenVerified')
+                }
+            }).catch( error => {
+                commit('TokenStorage/TokenExpired')
+            })
+        },
     }
 }
 

--- a/blog_project/frontend/src/store/TokenStorage.js
+++ b/blog_project/frontend/src/store/TokenStorage.js
@@ -11,9 +11,10 @@ const TokenStorage = {
     state: {
         accessTokenKey: '',
         refreshTokenKey: '',
+        verified: false,
     },
     getters: {
-        GetTokenKey: (state) => {
+        GetAccessTokenKey: (state) => {
             return state.accessTokenKey
         },
         GetHeaderForAuthorization: (state) => {
@@ -23,7 +24,10 @@ const TokenStorage = {
         },
         HasTokenKey: (state) => {
             return state.accessTokenKey.length > 0
-        }
+        },
+        GetDataForVerification: (state) => {
+            return `Bearer ${state.accessTokenKey}`
+        },
     },
     mutations: {
         SaveTokenData(state, data) {
@@ -33,6 +37,12 @@ const TokenStorage = {
         ClearTokenData(state) {
             state.accessTokenKey = ''
             state.refreshTokenKey = ''
+        },
+        TokenVerified(state) {
+            state.verified = true
+        },
+        TokenExpired(state){
+            state.verified = false
         }
     }
 }


### PR DESCRIPTION
1. Changed managing 404 error route. Removed redirecting, add props for see urls for more information.
2. Added TokenVerifyView into django.
3. When not authenticated user access to articleListPage, doesn't see
createArticle router-link. Also sign out link is same. Delete article,
update article link are same. But direct url access is still possible
without authorization.
4. For #3, add global mixin. it is tokenMixin for check that token is verified.

### Check Verification
먼저 SimpleJWT에서 지원하는 TokenVerifyView를 django에 추가했었다.
ProfileApi에서 Verify액션을 추가해, 이 경로로 접근하여 토큰이 정상적인지 검사한다.
**Promise**로 처리를 하므로, 곧바로 참,거짓을 반환받질 못한다. 
그래서 TokenStorage에 검증되었는지를 저장하고 이 값을 조회하기로 결정했다.

이걸 조회하려면 mapState({'isTokenVerified' ... 같은 상당히 귀찮은 코드를 매 컴포넌트마다 반복해야 하므로 믹스인이 필요해졌다.

전역으로 tokenMixin을 추가해, mapState나 mapGetters를 import하게 되는 코드를 쓰지 않고 깔끔하게 쓸 수 있게 만들었다.
tokenMixin은 `IsTokenVerified()` 메소드 한 가지밖에 갖고 있지 않다. TokenStorage의 verified를 그대로 넘겨준다.
verified는 Sign in, Sign out, (...그 외 refresh를 할 때?)같은 액션에만 바뀌어야 한다. 
> 주의할 점 ::: localStorage에 그대로 노출되어 있다. persistedstate때문에 그런데, 옮겨야 한다.

`createApp(app).mixin(tokenMixin).use(...`로 전역믹스인을 추가했다.

이제 템플릿에서 IsTokenVerified로 간단하게, 다른 코드가 필요없이 조회할 수 있다. 

### Managing 404 Error
redirect되던 route를 지우고, NotFound 컴포넌트에 props로 url을 넘기도록 했다.
그다음 템플릿에서 접근한 url을 표시했다. 이걸 뭐라고 부르던데 모르겠다.

### TODO
1. url로 접근하는 경우 허용되지 않은 접근이므로 예외처리가 필요하다.
- 허용되지 않은 접근이라고 알려준 후 리다이렉트되어야 한다.
2. state.TokenStorage.verified가 localStorage에 노출되어있다. 유저가 임의로 수정이 가능하다!
- paths에서 특정 state만 지정할 수 있다. verified는 노출시키지 말자.