### PR TITLE
Now when request to backend, check that user had token.

### DIFF
--- a/blog_project/frontend/src/components/AppNavigation.vue
+++ b/blog_project/frontend/src/components/AppNavigation.vue
@@ -1,14 +1,14 @@
 <template>
 <div>
     <div id='nav'>
+        {{ isVerified }}
         <router-link :to="{name: 'ListArticle'}">Blog</router-link>
-        <div v-if="IsTokenVerified">
-            <router-link :to="{name: 'SignOut'}">Sign Out</router-link>
-        </div>
-        <div v-else>
-            <router-link :to="{name: 'SignUp'}">Sign Up</router-link>
-            <router-link :to="{name: 'SignIn'}">Sign In</router-link>
-        </div>
+        <router-link :to="{name: 'SignOut'}">Sign Out</router-link>
+        <router-link :to="{name: 'SignUp'}">Sign Up</router-link>
+        <router-link :to="{name: 'SignIn'}">Sign In</router-link>
+        <button v-on:click="Clear">
+            Remove Token
+        </button>
     </div>
 </div>
 
@@ -19,6 +19,11 @@
 
     export default{
         name: 'AppNavigation',
+        methods: {
+            Clear(){
+                this.$store.commit('TokenStorage/ClearTokenData')
+            }
+        }
     }
 </script>
 

--- a/blog_project/frontend/src/components/Blog/CreateArticle.vue
+++ b/blog_project/frontend/src/components/Blog/CreateArticle.vue
@@ -17,7 +17,7 @@
 <script>
     
     export default{
-        data(){
+        data() {
             return{
                 article: {
                     title: "",
@@ -26,18 +26,22 @@
                 errorMsg: "",
             }
         },
+        created() {
+            this.NavigateToSignInPageIfNotAuthenticated()
+        },
         methods: {
             CreateArticle(){
                 if(this.IsEmptyArticle()){
                     this.ShowErrorMsg()
                     return
                 }
+
                 this.$store.dispatch(
                     'CreateArticle', this.article
                 ).then( response => {
                     this.$router.push({name: 'ListArticle'});
-                }).catch( error => {
-                    console.log(error.response)
+                }).catch(error => {
+                    this.$router.push({name: 'SignIn'})
                 })
             },
             IsEmptyArticle(){

--- a/blog_project/frontend/src/components/Blog/ListArticle.vue
+++ b/blog_project/frontend/src/components/Blog/ListArticle.vue
@@ -1,20 +1,18 @@
 <template>
 <div>
-    <div v-if="IsTokenVerified">
-        <div id="blog-create-article">
-            <router-link :to="{name: 'CreateArticle'}">
-                Create Article
-            </router-link>
-        </div>
-        <hr>
+    <div id="blog-create-article">
+        <router-link :to="{name: 'CreateArticle'}">
+            Create Article
+        </router-link>
     </div>
+    <hr>
     <div id="blog-article-list" >
         <div v-for="article in articleList" 
              :key="article.id">
             <router-link :to="{
-                              name: 'RetrieveArticle',
-                              params: {articleId: `${article.id}`}}
-                              ">
+              name: 'RetrieveArticle',
+              params: {articleId: `${article.id}`}}
+              ">
                 {{ article.title }}
             </router-link>
         </div>
@@ -22,8 +20,7 @@
 </div>
 </template>
 <script>
-    import { mapState } from 'vuex'
-    import { mapGetters } from 'vuex'
+    import { mapGetters, mapState } from 'vuex'
 
     export default {
         computed:{
@@ -31,7 +28,7 @@
                 articleList: 'GetArticleList'
             }),
         },
-        mounted(){
+        created(){
             this.$store.dispatch('ListArticle').catch(error => {
                 console.log(error);
             })

--- a/blog_project/frontend/src/components/Blog/RetrieveArticle.vue
+++ b/blog_project/frontend/src/components/Blog/RetrieveArticle.vue
@@ -4,22 +4,25 @@
             Back to Home
         </router-link>
         <hr>
-        title : {{ article.title }}
-        <br/>
-        created : {{ article.create_at }}
-        <br/>
-        last_modified : {{ article.last_modified_at }}
-        <br/>
-        content : {{ article.content }}
-        <hr>
-        <div v-if="IsTokenVerified">
-            <button v-on:click="DeleteArticle">
-                Delete!    
-            </button>
-            <button v-on:click="UpdateArticle">
-                Update!    
-            </button>
+        <div id="title">
+            <div>
+                {{ article.title }}
+            </div>
+            <div>
+                created : {{ article.create_at }}
+                <br/>
+                last_modified : {{ article.last_modified_at }}
+            </div>
         </div>
+        <hr/>
+        {{ article.content }}
+        <hr>
+        <button v-on:click="DeleteArticle">
+            Delete!    
+        </button>
+        <button v-on:click="UpdateArticle">
+            Update!    
+        </button>
     </div>
 </template>
 
@@ -62,14 +65,26 @@
                 this.$store.dispatch(
                     'DestroyArticle', this.articleId
                 ).then( response => {
-                    this.$router.push({name: 'ListArticle'});
+                    this.$router.push({
+                        name: 'ListArticle'
+                    });
+                }).catch(error => {
+                    // TODO 
+                    // headers에 토큰을 넘기기 때문에 인증을 거친 후 삭제 요청을 할 이유는 없다.(중복이므로)
+                    // 그럼 인증이 안된 경우, 서버가 다운된 경우 등등을 어떻게 처리할 것인가?
+                    if(error.response.status == 401){
+                        alert('접근 권한이 없습니다.')
+                        this.$router.push({name: 'SignIn'})
+                    }
+                    console.log(error)
                 })
             }
         }
     }
 </script>
-<style>
-    button{
-        background-color:#ffcccc;
+<style scoped>
+    #title{
+        display: flex;
+        justify-content: space-between;
     }
 </style>

--- a/blog_project/frontend/src/components/Blog/UpdateArticle.vue
+++ b/blog_project/frontend/src/components/Blog/UpdateArticle.vue
@@ -28,6 +28,9 @@
                 article: 'GetArticle'
             }),
         },
+        created(){
+            this.NavigateToSignInPageIfNotAuthenticated()
+        },
         mounted(){
             this.RetrieveArticle()
         },
@@ -53,7 +56,7 @@
                 }).catch(error => {
                     console.log(error)
                 })
-            }
+            },
         }
     }
 </script>

--- a/blog_project/frontend/src/components/Profile/SignIn.vue
+++ b/blog_project/frontend/src/components/Profile/SignIn.vue
@@ -36,7 +36,6 @@
                 this.$store.dispatch(
                     'SignIn', this.profile
                 ).then(response => {
-                    this.$store.commit('TokenStorage/TokenVerified')
                     this.$router.push({name: 'ListArticle'})
                 }).catch(
                     error => {

--- a/blog_project/frontend/src/components/Profile/SignOut.vue
+++ b/blog_project/frontend/src/components/Profile/SignOut.vue
@@ -8,7 +8,6 @@ export default{
     name: 'Sign Out',
     mounted(){
         this.$store.commit('TokenStorage/ClearTokenData')
-        this.$store.commit('TokenStorage/TokenExpired')
         this.$router.push({name: 'ListArticle'})
     }
 }

--- a/blog_project/frontend/src/mixins/tokenMixin.js
+++ b/blog_project/frontend/src/mixins/tokenMixin.js
@@ -1,10 +1,17 @@
+
+import { mapState } from 'vuex'
+
 export default {
     computed:{
-        IsTokenVerified() {
-            if(this.$store.state.TokenStorage.verified){
-                return true
-            }
-            return false
+        ...mapState([
+            'isVerified'
+        ])
+    },
+    methods:{
+        NavigateToSignInPageIfNotAuthenticated(){
+            this.$store.dispatch('VerifyToken').catch(errorMsg => {
+                this.$router.push({name: 'SignIn'})
+            })
         },
     }
 }

--- a/blog_project/frontend/src/store/AxiosApi/ArticleApi.js
+++ b/blog_project/frontend/src/store/AxiosApi/ArticleApi.js
@@ -43,14 +43,6 @@ const ArticleApi = {
                 commit('SetArticleList', response.data)
             })
         },
-        CreateArticle({ commit, rootGetters }, article){
-            return axios({
-                method: 'post',
-                url: articleUrl.GetArticleListCreateUrl(),
-                headers: rootGetters['TokenStorage/GetHeaderForAuthorization'],
-                data: article
-            })
-        },
         RetrieveArticle({ commit }, articleId){
             commit('SetArticle', undefined)
             return axios({
@@ -60,7 +52,17 @@ const ArticleApi = {
                 commit('SetArticle', response.data)
             })
         },
+        CreateArticle({ commit, rootGetters, dispatch }, article){
+            return axios({
+                method: 'post',
+                url: articleUrl.GetArticleListCreateUrl(),
+                headers: rootGetters['TokenStorage/GetHeaderForAuthorization'],
+                data: article
+            })
+        },
         UpdateArticle({ commit, rootGetters }, data){
+            // VerifyToken을 쓰지 않은 이유는, 
+            // headers에 가진 토큰이 정상이어야만 요청이 받아들여지기 때문이다.
             return axios({
                 method: 'put',
                 url: articleUrl.GetArticleRetrieveUpdateDestroyUrl(data.id),
@@ -68,7 +70,7 @@ const ArticleApi = {
                 data: data.article
             })
         },
-        DestroyArticle({ commit, rootGetters }, articleId){
+        DestroyArticle({ commit, rootGetters, dispatch }, articleId){
             return axios({
                 method: 'delete',
                 url: articleUrl.GetArticleRetrieveUpdateDestroyUrl(articleId),

--- a/blog_project/frontend/src/store/AxiosApi/ProfileApi.js
+++ b/blog_project/frontend/src/store/AxiosApi/ProfileApi.js
@@ -36,24 +36,27 @@ const ProfileApi = {
                 )
             })
         },
-        Verify({ commit, state, rootGetters }){
-            // TODO
-            // Promise에 대해 알아야겠다. action은 Promise를 이용해 작성..
-            // 
-            let accessTokenKey = rootGetters['TokenStorage/GetAccessTokenKey']
-            if(accessTokenKey.length == 0){
-                commit('TokenStorage/TokenExpired')
-            }
-            axios({
-                method: 'post',
-                url: profileUrl.GetVerifyTokenUrl(),
-                data: rootGetters['TokenStorage/GetDataForVerification'],
-            }).then( response => {
-                if(response.status == 200){
-                    commit('TokenStorage/TokenVerified')
+        VerifyToken({ commit,  rootGetters,  }){
+            return new Promise((resolve, reject) => {
+                let accessTokenKey = rootGetters['TokenStorage/GetAccessTokenKey']
+                if(accessTokenKey.length == 0){
+                    commit('TokenStorage/ClearTokenData')
+                    reject()
                 }
-            }).catch( error => {
-                commit('TokenStorage/TokenExpired')
+                else{
+                    axios({
+                        method: 'post',
+                        url: profileUrl.GetVerifyTokenUrl(),
+                        data: rootGetters['TokenStorage/GetDataForVerification'],
+                    }).then( response => {
+                        if(response.status == 200){
+                            resolve()
+                        }
+                    }).catch( error => {
+                        commit('TokenStorage/ClearTokenData')
+                        reject()
+                    })
+                }
             })
         },
     }

--- a/blog_project/frontend/src/store/TokenStorage.js
+++ b/blog_project/frontend/src/store/TokenStorage.js
@@ -2,7 +2,8 @@ import createPersistedState from 'vuex-persistedstate'
 
 const persistedState = createPersistedState({
     paths: [
-        'TokenStorage',
+        'TokenStorage.accessTokenKey',
+        'TokenStorage.refreshTokenKey',
     ]
 })
 
@@ -11,7 +12,7 @@ const TokenStorage = {
     state: {
         accessTokenKey: '',
         refreshTokenKey: '',
-        verified: false,
+        isVerified: false,
     },
     getters: {
         GetAccessTokenKey: (state) => {
@@ -26,24 +27,22 @@ const TokenStorage = {
             return state.accessTokenKey.length > 0
         },
         GetDataForVerification: (state) => {
-            return `Bearer ${state.accessTokenKey}`
+            return {
+                token: `${state.accessTokenKey}`
+            }
         },
     },
     mutations: {
         SaveTokenData(state, data) {
             state.accessTokenKey = data.access
             state.refreshTokenKey = data.refresh
+            state.isVerified = true
         },
         ClearTokenData(state) {
             state.accessTokenKey = ''
             state.refreshTokenKey = ''
+            state.isVerified = false
         },
-        TokenVerified(state) {
-            state.verified = true
-        },
-        TokenExpired(state){
-            state.verified = false
-        }
     }
 }
 


### PR DESCRIPTION
### 인증되지 않은 요청 제한
vue-router에서 매 path마다 옵션을 줘서 그 옵션을 참고해 접근을 제한할까, 생각해봤다. 
당장은 그 생각을 구현할 방법이 떠오르지 않아서 매 컴포넌트마다 created에서 직접 메소드를 호출해 검사하기로 했다.
tokenMixin에 메소드를 넣어놓고 글로벌 믹스인으로 둔다음 제한할 컴포넌트에만 넣기로 했다.
[이런 방법도 있는것 같다.](https://next.router.vuejs.org/guide/advanced/navigation-guards.html#per-route-guard)

라우팅에는 제한이 없지만, 컴포넌트 생성 시 가지고 있는 토큰을 검증한다. 실패할 경우 SignIn페이지로 다이렉트 된다.

### VerifyToken
갖고 있는 토큰이 정상적인지를 알기 위해서는 SimpleJWT에 TokenVerifyView를 이용해야한다.
그런데 action에서 그 api에 접근해 결과를 받아와 컴포넌트에게 돌려주기 위해서는 Promise객체에 대해 이해해야했다.
먼저 토큰이 없다면 reject, data에 `token: <access_token>`으로 값을 넘긴 후 상태 코드가 200일 경우에만 resolve, 아닐 경우 reject.

### TODO
- http status code에 따라 다른 에러 헨들링의 필요성
api를 사용할 때마다 Promise객체를 이용하는데 에러가 발생했을 때 console.log만 띄울 것인가?