### PR TITLE
Refresh token when access token invalid.

### DIFF
--- a/blog_project/blog_project/settings/local.py
+++ b/blog_project/blog_project/settings/local.py
@@ -22,7 +22,7 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(hours=2),
+    'ACCESS_TOKEN_LIFETIME': timedelta(seconds=10),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
     'ROTATE_REFRESH_TOKENS': False,
     'BLACKLIST_AFTER_ROTATION': True,

--- a/blog_project/frontend/src/components/Blog/ListArticle.vue
+++ b/blog_project/frontend/src/components/Blog/ListArticle.vue
@@ -35,7 +35,6 @@
         },
         created(){
             this.$store.dispatch('ListArticle')
-            this.$store.dispatch('VerifyToken')
         },
     }
 </script>

--- a/blog_project/frontend/src/components/Blog/ListArticle.vue
+++ b/blog_project/frontend/src/components/Blog/ListArticle.vue
@@ -23,6 +23,11 @@
     import { mapGetters, mapState } from 'vuex'
 
     export default {
+        data(){
+            return {
+                isVerified: false
+            }
+        },
         computed:{
             ...mapGetters({
                 articleList: 'GetArticleList'
@@ -30,6 +35,7 @@
         },
         created(){
             this.$store.dispatch('ListArticle')
+            this.$store.dispatch('VerifyToken')
         },
     }
 </script>

--- a/blog_project/frontend/src/components/Profile/SignIn.vue
+++ b/blog_project/frontend/src/components/Profile/SignIn.vue
@@ -35,11 +35,8 @@
             SignIn(){
                 this.$store.dispatch(
                     'SignIn', this.profile
-                ).then(response => {
-                    this.$router.push({name: 'ListArticle'})
-                }).catch(
+                ).catch(
                     error => {
-                        console.dir(error)
                         if(error.response.status == 401){
                             this.error_msg = '일치하는 계정이 없습니다.'
                         }

--- a/blog_project/frontend/src/components/Profile/SignUp.vue
+++ b/blog_project/frontend/src/components/Profile/SignUp.vue
@@ -57,9 +57,7 @@
 
                 this.$store.dispatch(
                     'SignUp', this.profile
-                ).then( response => {
-                    this.$router.push({name: 'ListArticle'})
-                })
+                )
             },
             IsPasswordEquals(){
                 return this.profile.password == this.profile.password_confirmation

--- a/blog_project/frontend/src/router/index.js
+++ b/blog_project/frontend/src/router/index.js
@@ -22,23 +22,20 @@ const router = createRouter({
     routes,
 })
 
-router.beforeEach(async (to, from, next) => {
+router.beforeEach(async(to, from, next) => {    
+    //Check route require authentication
     if(to.meta.requiresAuthentication){
         try{
             const response = await store.dispatch('VerifyToken')
             if(response.status == 200){
                 next()
             }
-            else if(response.status >= 400){
-                next(false)
-            }
             else{
-                alert('로그인이 필요합니다.')
-                next('/SignIn')
+                throw response
             }
         }
         catch(e){
-            alert('로그인이 필요합니다.')
+            alert('권한이 없습니다. 로그인 페이지로 이동합니다.')
             next('/SignIn')
         }
     }

--- a/blog_project/frontend/src/store/BackendApi/articleApi.js
+++ b/blog_project/frontend/src/store/BackendApi/articleApi.js
@@ -55,7 +55,6 @@ const ArticleApi = {
             axiosInstance({
                 method: 'post',
                 url: articleUrl.GetArticleListCreateUrl(),
-                headers: rootGetters['TokenStorage/GetHeaderForAuthorization'],
                 data: article
             }).then( response => {
                 router.push({name: 'ListArticle'});
@@ -68,7 +67,6 @@ const ArticleApi = {
             axiosInstance({
                 method: 'put',
                 url: articleUrl.GetArticleRetrieveUpdateDestroyUrl(data.id),
-                headers: rootGetters['TokenStorage/GetHeaderForAuthorization'],
                 data: data.article
             }).then( response => {
                 router.push({
@@ -84,7 +82,6 @@ const ArticleApi = {
             axiosInstance({
                 method: 'delete',
                 url: articleUrl.GetArticleRetrieveUpdateDestroyUrl(articleId),
-                headers: rootGetters['TokenStorage/GetHeaderForAuthorization'],
             }).then( response => {
                 router.push({name: 'ListArticle'})
             }).catch( error => {

--- a/blog_project/frontend/src/store/BackendApi/axiosWrapper.js
+++ b/blog_project/frontend/src/store/BackendApi/axiosWrapper.js
@@ -13,16 +13,13 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
     config => {
         console.log(config)
-        if(config.headers.Authorization !== undefined){
-            config.headers = store.getters['TokenStorage/GetHeaderForAuthorization']
-        }
+        config.headers.Authorization = `Bearer ${store.state.TokenStorage.accessToken}`
         return config
     },
     error => {
         return Promise.reject(error)
     }
 )
-//참고 : https://kdinner.tistory.com/60
 
 axiosInstance.interceptors.response.use(
     undefined,
@@ -32,9 +29,8 @@ axiosInstance.interceptors.response.use(
            error.config.isRetried === undefined){
             console.log('need refresing')
             error.config.isRetried = true
+            
             await store.dispatch('RefreshToken')
-
-            error.config.data = store.getters['TokenStorage/GetDataForVerifyAccessToken']
             return await axiosInstance(error.config)
         }
         else{

--- a/blog_project/frontend/src/store/BackendApi/axiosWrapper.js
+++ b/blog_project/frontend/src/store/BackendApi/axiosWrapper.js
@@ -1,24 +1,45 @@
 import axios from 'axios'
 
+import store from '/src/store/store'
+
 
 const backendApiUrl = 'http://rest-blog.run.goorm.io/api/'
 
 const axiosInstance = axios.create({
     baseURL: backendApiUrl,
-    timeout: 2000,
-    
+    timeout: 1500,
 })
 
-axiosInstance.interceptors.response.use(
-    response => {
-        console.log(response)
-        if(response.status >= 400){
-            console.log("error over 400")
+axiosInstance.interceptors.request.use(
+    config => {
+        console.log(config)
+        if(config.headers.Authorization !== undefined){
+            config.headers = store.getters['TokenStorage/GetHeaderForAuthorization']
         }
-        return response
+        return config
     },
     error => {
         return Promise.reject(error)
+    }
+)
+//참고 : https://kdinner.tistory.com/60
+
+axiosInstance.interceptors.response.use(
+    undefined,
+    async error => {
+        console.log('accessToken is invalid')
+        if(error.response.status == 401 &&
+           error.config.isRetried === undefined){
+            console.log('need refresing')
+            error.config.isRetried = true
+            await store.dispatch('RefreshToken')
+
+            error.config.data = store.getters['TokenStorage/GetDataForVerifyAccessToken']
+            return await axiosInstance(error.config)
+        }
+        else{
+            return Promise.reject(error)
+        }
     }
 )
 

--- a/blog_project/frontend/src/store/tokenStorage.js
+++ b/blog_project/frontend/src/store/tokenStorage.js
@@ -19,6 +19,9 @@ const TokenStorage = {
             return state.accessToken
         },
         GetHeaderForAuthorization: (state) => {
+            if(state.accessToken == ''){
+                return {}
+            }
             return {
                 Authorization: `Bearer ${state.accessToken}`
             }

--- a/blog_project/frontend/src/store/tokenStorage.js
+++ b/blog_project/frontend/src/store/tokenStorage.js
@@ -1,47 +1,53 @@
 import createPersistedState from 'vuex-persistedstate'
 
+
 const persistedState = createPersistedState({
     paths: [
-        'TokenStorage.accessTokenKey',
-        'TokenStorage.refreshTokenKey',
+        'TokenStorage.accessToken',
+        'TokenStorage.refreshToken',
     ]
 })
 
 const TokenStorage = {
     namespaced: true,
     state: {
-        accessTokenKey: '',
-        refreshTokenKey: '',
-        isVerified: false,
+        accessToken: '',
+        refreshToken: '',
     },
     getters: {
-        GetAccessTokenKey: (state) => {
-            return state.accessTokenKey
+        GetAccessToken: (state) => {
+            return state.accessToken
         },
         GetHeaderForAuthorization: (state) => {
             return {
-                Authorization: `Bearer ${state.accessTokenKey}`
+                Authorization: `Bearer ${state.accessToken}`
             }
         },
-        HasTokenKey: (state) => {
-            return state.accessTokenKey.length > 0
+        HasToken: (state) => {
+            return state.accessToken.length > 0
         },
-        GetDataForVerification: (state) => {
+        GetDataForVerifyAccessToken: (state) => {
             return {
-                token: `${state.accessTokenKey}`
+                token: `${state.accessToken}`
+            }
+        },
+        GetDataForRefreshToken: (state) => {
+            return {
+                refresh: `${state.refreshToken}`
             }
         },
     },
     mutations: {
         SaveTokenData(state, data) {
-            state.accessTokenKey = data.access
-            state.refreshTokenKey = data.refresh
-            state.isVerified = true
+            state.accessToken = data.access
+            state.refreshToken = data.refresh
+        },
+        SaveAccessToken(state, accessToken) {
+            state.accessToken = accessToken
         },
         ClearTokenData(state) {
-            state.accessTokenKey = ''
-            state.refreshTokenKey = ''
-            state.isVerified = false
+            state.accessToken = ''
+            state.refreshToken = ''
         },
     }
 }


### PR DESCRIPTION
django 세팅에서 SIMPLE_JWT 딕셔너리에 토큰에 대한 설정을 할 수 있었다. 
여기서 access token의 수명을 정할 수 있는데, 이 기간이 지난 토큰은 인증에 실패한다.
토큰을 계속 새로 제공해야 보안에 강할 것 같다. 아마?

SimpleJWT의 TokenRefreshView를 이용해 refresh token을 제출하면 새로 access token을 제공한다.
갱신은 언제? access token이 만료될 때마다.
사용자가 요청을 할 때 만료된 토큰을 사용하면 **401 Unauthorized**인 response를 얻게 된다. 
매 axios를 사용할 때마다 catch에 갱신코드를 작성하면 중복이 심하다. 따라서 인스턴스 내에 있는 Interceptor를 이용해야 한다.

# [Axios Instance](https://axios-http.com/docs/interceptors)
요청하기 직전(request), 응답을 받은 직후(response) 시점에서 처리를 할 수 있다.

401 Unauthorized 응답을 받았다면 인증에 실패한 것인데 몇 가지 경우가 있다.
### 토큰이 없는 경우 (로그아웃 상태)
access token, refresh token 둘 다 없다. 이를 얻기 위해서는 로그인 뿐이다.
로그인페이지로 이동되도록 한다. 
### 토큰이 만료된 경우 (로그인 상태)
일단 401에러가 캐치되어 있다. `axios.interceptors.response.use`에서 제일 먼저 캐치할 수 있다.
401에러라면 갱신요청을 한다. 그리고 갱신요청이 실패했을 때 또다시 갱신요청을 하지 않기 위해 트릭을 넣는다.
이 외에는 잘 모르겠다.

이 프로젝트에서는 라우터를 이용해 컴포넌트를 이동할 때마다 access token을 검증한다. 
path마다 meta 값으로 인증이 필요한 컴포넌트를 선별할 수 있다. 이 컴포넌트들만 검증한다. 
... 사실 매 라우팅마다 인증해야되는것 같다.


### TODO 
- 아직 토큰이 없는 경우는 처리하지 못했다. get요청일 때도 검증하는데, 토큰이 없을 때는 헤더값을 안 넣도록 바꿔야겠다.